### PR TITLE
Update rand to 0.8

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -27,7 +27,7 @@ sentry-types = { version = "0.21.0", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
 lazy_static = "1.4.0"
 im = { version = "15.0.0", optional = true }
-rand = { version = "0.7.3", optional = true }
+rand = { version = "0.8", optional = true }
 serde_json = "1.0.46"
 log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
 


### PR DESCRIPTION
Ark this currently pinned to `744c315` which isn't where `master` is. So I made a new branch called `ark-is-here` and this PR is into that. Basically I need to update rand to 0.8 to update to quickcheck 1.0. Pulling in two versions of rand currently.